### PR TITLE
⚡️ Ignore yarn engines

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,8 @@ git update-index --assume-unchanged .github/workflows/*
 echo "## Your environment is not ready yet. Installing modules..."
 if [ -f yarn.lock ]; then
     echo "## Detected yarn as package manager"
-    yarn --non-interactive --silent --ignore-scripts --production=false
+    yarn --non-interactive --silent --ignore-scripts --ignore-engines --production=false
+    yarn config set ignore-engines true
     echo "## Installing dependencies..."
     yarn install
     echo "## Linting code..."


### PR DESCRIPTION
Yarn will die if it is using an incompatible node version from the version in specified `package.json`. This is useful for applications that need to run (like bigtest server), but is not super necessary when all that you want to do is lint.

This sets the `--ignore-engines` flag when running yarn so whatever version is on the docker container will be fine.

See here for an example of how this fails otherwise:

https://github.com/bigtestjs/server/commit/c897b921105119463bbf6836c022dbd0d77fa323/checks?check_suite_id=302641467#step:3:20